### PR TITLE
Moving keys around

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ I lent my keyboard to a friend, so I use this
 
 ## DISCLAIMER
 
-Do **NOT** trust this code too much, it was generated with ChatGPT
+You cand kinda trust this code, some of it was generated with ChatGPT, mostly the Audio API, but I took good care in cleaning it

--- a/index.html
+++ b/index.html
@@ -5,11 +5,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="style.css">
+
+    <script src="script.js"></script>
+
     <title>Mini keyboard</title>
 </head>
 
 <body>
     <table>
+        <h1>The infos in the table are outdated: I am moving the keys around</h1>
         <thead>
             <tr class="info">
                 <th>Keys</th>
@@ -18,34 +22,64 @@
         </thead>
         <tbody>
             <tr class="info">
-                <th>2-7</th>
-                <th>semitones C4</th>
+                <th>Upper 2 rows of the keyboard</th>
+                <th>High piano keyboard (F -> "q")</th>
             </tr>
             <tr class="info">
-                <th>Q-U</th>
-                <th>scale C4</th>
+                <th>Lower 2 rows of the keyboard</th>
+                <th>Low piano keyboard (F -> "`")</th>
             </tr>
             <tr class="info">
                 <th>S-J</th>
-                <th>semitones C3</th>
+                <th>Lower semitones</th>
             </tr>
             <tr class="info">
-                <th>Z-M</th>
-                <th>scale C3</th>
-            </tr>
-            <tr class="info">
-                <th>Shift</th>
-                <th>raise by 2 octaves (you need an american keyboard layout for the higher semitones to work
-                    correctly)</th>
-            </tr>
-            <tr class="info">
-                <th>P, O, I</th>
-                <th>kick, snare, crash</th>
+                <th>"\", "]", "="</th>
+                <th>kick, snare, crash respectively</th>
             </tr>
         </tbody>
     </table>
-    <p><a href="charts.html" target="_blank">Theory chart</a></p>
-    <script src="script.js"></script>
+    <h2>Register: <span id="shift-register" style="color:green;">↓ Low</span></h2>
+    <div class="horizontal">
+        <h2>Oscillator shape:</h2>
+        <button type="button" label="-" name="harmonic-up" onclick="setHarmonics(-1)">-</button>
+        <button type="button" text="+" name=" harmonic-up" onclick="setHarmonics(+1)">+</button>
+        <h2>harmonics</h2>
+    </div>
+    <div id="oscillator-shape" class="horizontal">
+        <div>
+            <h3>Harmonic[0] shape</h3>
+            <form id="h0-shapes" class="vertical">
+                <label><input type="radio" value="sine" name="h0-shape" checked>Sine</label>
+                <label><input type="radio" value="square" name="h0-shape">Square</label>
+                <label><input type="radio" value="triangle" name="h0-shape">Triangle</label>
+                <label><input type="radio" value="sawtooth" name="h0-shape">Sawtooth</label>
+            </form>
+        </div>
+        <div>
+            <h3>Harmonic[1] shape</h3>
+            <form id="h1-shapes" class="vertical">
+                <label><input type="radio" value="sine" name="h1-shape">Sine</label>
+                <label><input type="radio" value="square" name="h1-shape">Square</label>
+                <label><input type="radio" value="triangle" name="h1-shape" checked>Triangle</label>
+                <label><input type="radio" value="sawtooth" name="h1-shape">Sawtooth</label>
+            </form>
+        </div>
+    </div>
+    <p><a href="charts.html" target="_blank">Theory chart</a>
+        <span class="todo">not written yet</span>
+    </p>
+    <p><a href="https://github.com/3isvogel/piano" target="_blank">Repository for this project</a></p>
+    <h2>Known problems</h2>
+    <ol>
+        <li>
+            <p> MacOS keyboard can't handle more keypresses on the same column,<br>
+                this make sense since normally you would have at maximum a finger per column,<br>
+                to replicate: strike a chord: ZCB, keys QET won't play any sound, but WRY plays normally<br>
+                I will call this the <span class="todo">Q(ui)ET WRY </span> problem
+            </p>
+        </li>
+    </ol>
 </body>
 
 </html>

--- a/script.js
+++ b/script.js
@@ -1,45 +1,103 @@
 const audioContext = new (window.AudioContext || window.webkitAudioContext)();
 const activeKeys = {}; // To keep track of currently active keys
 const activeSounds = {};
+const shift_register = document.getElementById("shift-register");
+// maybe a better way exixts, IDC, I will do how you do in microcontrollers + the toggle
+const shift_octaves = 2;
+let shift_toggle = false;
+let shift_state = false;
+let shift_prev_state = false;
+
+function oct(note, octaves) {
+    const mult = 2 ** octaves;
+    return note * mult;
+}
+
+const step_size = 2 ** (1 / 12)
+function stp(note, steps) {
+    return note * step_size ** steps;
+}
+
+// Tune the A4 and then tune the whole piano
+// on it shifting the available register up "BASE" octaves
+const A4 = 440;
+const BASE = 2;
+
+const A0 = oct(A4, -4);
+// this way the frequencies are define once, to raise/lower all the keys just change the base number
+const A = oct(A0, BASE);
+const As = stp(A, 1);
+const B = stp(A, 2);
+const C = stp(A, -9);
+const Cs = stp(A, -8);
+const D = stp(A, -7);
+const Ds = stp(A, -6);
+const E = stp(A, -5);
+const F = stp(A, -4);
+const Fs = stp(A, -3);
+const G = stp(A, -2);
+const Gs = stp(A, -1);
 
 // Map of keys to frequencies
-const keyFrequencyMap = {
-    'z': 130.81,  // C3
-    's': 138.59,  // C#3/D♭3
-    'x': 146.83,  // D3
-    'd': 155.56,  // D#3/E♭3
-    'c': 164.81,  // E3
-    'v': 174.61,  // F3
-    'g': 185.00,  // F#3/G♭3
-    'b': 196.00,  // G3
-    'h': 207.65,  // G#3/A♭3
-    'n': 220.00,  // A3
-    'j': 233.08,  // A#3/B♭3
-    'm': 246.94,  // B3
+// FIXME: Using toggle switch makes every key work regardless if they are latin or symbols,
+//        however some keys don't make any sound when shift key is pressed, since they send a different keycode
 
-    'q': 261.63,  // C4
-    '2': 277.18,  // C#4/D♭4
-    '@': 277.18,  // C#4/D♭4
-    'w': 293.66,  // D4
-    '3': 311.13,  // D#4/E♭4
-    '#': 311.13,  // D#4/E♭4
-    'e': 329.63,  // E4
-    'r': 349.23,  // F4
-    '5': 369.99,  // F#4/G♭4
-    '%': 369.99,  // F#4/G♭4
-    't': 392.00,  // G4
-    '6': 415.30,  // G#4/A♭4
-    '^': 415.30,  // G#4/A♭4
-    'y': 440.00,  // A4
-    '7': 466.16,  // A#4/B♭4
-    '&': 466.16,  // A#4/B♭4
-    'u': 493.88,  // B4
+// TODO: Provide different keymapping layout to choose from, and save them as separate files
+const keyFrequencyMap = {
+
+    // Lower scale: C tones
+    '`': oct(F, 0),
+    'z': oct(G, 0),
+    'x': oct(A, 0),
+    'c': oct(B, 0),
+    'v': oct(C, 1),
+    'b': oct(D, 1),
+    'n': oct(E, 1),
+    'm': oct(F, 1),
+    ',': oct(G, 1),
+    '.': oct(A, 1),
+    '/': oct(B, 1),
+
+    // Lower scale: C semitones
+    'a': oct(Fs, 0),
+    's': oct(Gs, 0),
+    'd': oct(As, 0),
+    'g': oct(Cs, 1),
+    'h': oct(Ds, 1),
+    'k': oct(Fs, 1),
+    'l': oct(Gs, 1),
+    ';': oct(As, 1),
+
+    // Higher scale: C tones
+    'q': oct(F, 1),
+    'w': oct(G, 1),
+    'e': oct(A, 1),
+    'r': oct(B, 1),
+    't': oct(C, 2),
+    'y': oct(D, 2),
+    'u': oct(E, 2),
+    'i': oct(F, 2),
+    'o': oct(G, 2),
+    'p': oct(A, 2),
+    '[': oct(B, 2),
+
+    // Higher scale: C semitones
+    '2': oct(Fs, 1),
+    '3': oct(Gs, 1),
+    '4': oct(As, 1),
+    '6': oct(Cs, 2),
+    '7': oct(Ds, 2),
+    '9': oct(Fs, 2),
+    '0': oct(Gs, 2),
+    '-': oct(As, 2),
+
+    '§': A4 // A4 standard tuning
 };
 
 let keySoundMap = {
-    'p': "sounds/kick.ogg",
-    'o': "sounds/snare.ogg",
-    'i': "sounds/crash.ogg",
+    '\\': "sounds/kick.ogg",
+    ']': "sounds/snare.ogg",
+    '=': "sounds/crash.ogg",
 };
 
 function playAudio(name) {
@@ -51,52 +109,48 @@ function playAudio(name) {
 
 function playPianoKey(frequency) {
     // Create new gain nodes and oscillators for each note
-    const gainNode = audioContext.createGain();
-    const harmonicGain = audioContext.createGain();
-    const oscillator1 = audioContext.createOscillator(); // Fundamental
-    const oscillator2 = audioContext.createOscillator(); // Harmonics
 
-    // Set oscillator types
-    oscillator1.type = 'sine'; // Fundamental frequency
-    oscillator2.type = 'triangle'; // Harmonics
+    const fadeOutDuration = 5; // Time before starting to fade out
 
-    // Set frequencies
-    oscillator1.frequency.setValueAtTime(frequency, audioContext.currentTime);
-    oscillator2.frequency.setValueAtTime(frequency * 2, audioContext.currentTime); // Second harmonic
+    const harmonicGains = new Array(harmonics);
+    const harmonicOscillators = new Array(harmonics);
+    const now = audioContext.currentTime;
 
-    // Connect oscillators to gains
-    oscillator1.connect(gainNode);
-    oscillator2.connect(harmonicGain);
-    harmonicGain.gain.setValueAtTime(0.05, audioContext.currentTime); // Set harmonics volume
-    harmonicGain.connect(gainNode);
-    gainNode.connect(audioContext.destination);
+    for (let i = 0; i < harmonics; i++) {
+        harmonicGains[i] = audioContext.createGain();
+        harmonicOscillators[i] = audioContext.createOscillator();
+        harmonicOscillators[i].type = document.querySelector(`input[name="h${i}-shape"]:checked`).value;
+        harmonicOscillators[i].frequency.setValueAtTime(oct(frequency, i), now);
+        harmonicOscillators[i].connect(harmonicGains[i]);
+        harmonicGains[i].gain.setValueAtTime(1 / (2 ** i), now);
+        // cascadian connect to destination
+        if (i == 0) {
+            harmonicGains[i].connect(audioContext.destination);
+        } else {
+            harmonicGains[i].connect(harmonicGains[i - 1]);
+        }
+        harmonicOscillators[i].start();
+        // Fade out over 5 seconds
+        harmonicOscillators[i].stop(now + fadeOutDuration);
+    }
 
-    // Start playing the sound
-    oscillator1.start();
-    oscillator2.start();
+    // only set to 0 the main gain node as the other are connected to it will fade out at the same time
+    harmonicGains[0].gain.linearRampToValueAtTime(0, now + fadeOutDuration);
 
-    // Set the gain node to full volume immediately
-    gainNode.gain.setValueAtTime(1, audioContext.currentTime);
-
-    // Store the gainNode for later use when stopping the sound
-    activeKeys[frequency] = { gainNode, oscillator1, oscillator2 };
-
-    // Set a timed fade-out after a specified duration
-    const fadeOutDuration = 5; // Time before starting to fade out (in seconds)
-
-    gainNode.gain.linearRampToValueAtTime(0, audioContext.currentTime + fadeOutDuration); // Fade out over 5 seconds
-    oscillator1.stop(audioContext.currentTime + fadeOutDuration);
-    oscillator2.stop(audioContext.currentTime + fadeOutDuration);
+    activeKeys[frequency] = { harmonics, harmonicGains, harmonicOscillators };
 }
 
 function stopPianoKey(frequency) {
     if (activeKeys[frequency]) {
-        const { gainNode, oscillator1, oscillator2 } = activeKeys[frequency];
+        const { harmonics, harmonicGains, harmonicOscillators } = activeKeys[frequency];
+
         const now = audioContext.currentTime;
 
-        gainNode.gain.linearRampToValueAtTime(0, now + 0.2);
-        oscillator1.stop(now + 0.2);
-        oscillator2.stop(now + 0.2);
+        // when key is released fade out quicker
+        harmonicGains[0].gain.linearRampToValueAtTime(0, now + 0.2);
+        for (let i = 0; i < harmonics; i++) {
+            harmonicOscillators[i].stop(now + 0.2)
+        }
 
         delete activeKeys[frequency];
     }
@@ -104,17 +158,19 @@ function stopPianoKey(frequency) {
 
 // Event listeners for key press
 document.addEventListener('keydown', function (event) {
+    // prevent default actions from triggering (eg: "/" for quicksearch)
+    event.preventDefault();
     const key = event.key.toLowerCase();
 
-    // handle sound keys
+    // Handle audio samples
     const sound = keySoundMap[key];
-
     if (sound && !activeSounds[key]) {
         activeSounds[key] = true;
         playAudio(sound)
         return;
     }
-    // TODO: add a text field to provide file path, allowing binding key to sound§
+
+    // TODO: add a text field to provide file path, allowing binding key to sound
     // TODO: extend functionality to any key, allowing drop-in configuration for all settings (to allow user-specific conf)
     // ideally, provide a parsed box of test where each eintry is a line in the form of:
     // <s|k><_sep_><key><_sep_><resource|frequency>
@@ -123,11 +179,20 @@ document.addEventListener('keydown', function (event) {
     //   resource: an URI to the specified resource, frequency: frequency to play
     //   <sep> still to decide if universal or user-specific, in this case the first line is something like: "sep:<sep>"
 
+    // Handle frequencies
     const frequency = keyFrequencyMap[key];
 
-    // Check if the Shift key is pressed
-    const shiftPressed = event.shiftKey;
-    const adjustedFrequency = shiftPressed ? frequency * 4 : frequency; // Raise by 2 octaves (2^2 = 4)
+    // Double state check on shift key for toggle
+    shift_state = event.shiftKey;
+    if (shift_state && !shift_prev_state) {
+        shift_toggle = !shift_toggle;
+        const shift_register = document.getElementById("shift-register");
+        shift_register.innerText = shift_toggle ? "↑ High" : "↓ Low";
+        shift_register.style["color"] = shift_toggle ? "blue" : "green";
+    } // well... toggle the toggle
+    shift_prev_state = shift_state;
+
+    const adjustedFrequency = oct(frequency, shift_toggle * shift_octaves);
 
     if (frequency && !activeKeys[adjustedFrequency]) {
         playPianoKey(adjustedFrequency); // Play the note if it's not already active
@@ -138,13 +203,42 @@ document.addEventListener('keyup', function (event) {
     const key = event.key.toLowerCase();
     const frequency = keyFrequencyMap[key];
 
+    shift_state = event.shiftKey;
+    if (shift_prev_state && !shift_state)
+        shift_prev_state = shift_state;
     if (frequency) {
         // Calculate the adjusted frequency for release
-        const shiftPressed = event.shiftKey;
-        const adjustedFrequency = shiftPressed ? frequency * 4 : frequency; // Raise by 2 octaves
+        const adjustedFrequency = oct(frequency, shift_toggle * shift_octaves);
 
         stopPianoKey(adjustedFrequency); // Stop the note
     }
 
     if (activeSounds[key]) activeSounds[key] = null;
 });
+
+let clamp = ((x, m, M) => { return x < m ? m : x > M ? M : x })
+
+// Start harmonics
+let harmonics = 2;
+const MIN_HARMONICS = 1;
+const MAX_HARMONICS = 4;
+function setHarmonics(modify) {
+    harmonics += modify;
+    harmonics = clamp(harmonics, MIN_HARMONICS, MAX_HARMONICS);
+    let e = document.getElementById("oscillator-shape")
+    e.innerHTML = ""
+    for (let h = 0; h < harmonics; h++) {
+        oscillator_selector =
+            `<div id="h${h}-shape">
+            <h3>Harmonic[${h}] shape</h3>
+            <form id="h${h}-shapes" class="vertical">
+            <label><input type="radio" value="sine" name="h${h}-shape" checked>Sine</label>
+            <label><input type="radio" value="square" name="h${h}-shape">Square</label>
+            <label><input type="radio" value="triangle" name="h${h}-shape">Triangle</label>
+            <label><input type="radio" value="sawtooth" name="h${h}-shape">Sawtooth</label>
+            </form>
+        </div>`
+        e.innerHTML += oscillator_selector
+    }
+
+}

--- a/style.css
+++ b/style.css
@@ -17,15 +17,26 @@ th {
     /* Adds a thick bottom border to the header */
 }
 
-tbody tr:hover {
-    background-color: #f9f9f9;
-    /* Optional: highlight row on hover */
-}
-
-.info {
+s .info {
     margin: 10px;
 }
 
 .todo {
     color: red;
+}
+
+.vertical {
+    display: flex;
+    flex-direction: column;
+}
+
+/* .horizontal: Places the elements side by side */
+.horizontal {
+    display: flex;
+    flex-direction: row;
+}
+
+h2,
+h3 {
+    margin: 10px 10px;
 }


### PR DESCRIPTION
- Keys have been remapped to fit a wider range and to overlap on the two rows
- Shift key now acts as a toggle
- Is possible to specify up to 4 harmonic oscillators to change the sound a bit
- Moved the drum kit on the far top right of the keyboard
- Added a standard A4 tune on the '§' key for tuning
- Interface modified to fit new changes
- AI-generated code cleaned
- Generate all frequencies based on the specified A4 and a base shift, will add possibility to modify later, probably
- Removed useless CSS rules